### PR TITLE
chore(deps): bump dependency versions

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -1,0 +1,5 @@
+# Dependency Matrix
+
+Dependency | Sources | Version | Mismatched versions
+---------- | ------- | ------- | -------------------
+[jstrachan/bdd-gh-1582792034](https://github.com/jstrachan/bdd-gh-1582792034.git) |  | []() | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,4 +2,4 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[jstrachan/bdd-gh-1582806522](https://github.com/jstrachan/bdd-gh-1582806522.git) |  | []() | 
+[jstrachan/bdd-gh-1582806619](https://github.com/jstrachan/bdd-gh-1582806619.git) |  | []() | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,4 +2,4 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[jstrachan/bdd-gh-1582792034](https://github.com/jstrachan/bdd-gh-1582792034.git) |  | []() | 
+[jstrachan/bdd-gh-1582806522](https://github.com/jstrachan/bdd-gh-1582806522.git) |  | []() | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - host: github.com
   owner: jstrachan
-  repo: bdd-gh-1582792034
-  url: https://github.com/jstrachan/bdd-gh-1582792034.git
+  repo: bdd-gh-1582806522
+  url: https://github.com/jstrachan/bdd-gh-1582806522.git
   version: ""
   versionURL: ""

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - host: github.com
   owner: jstrachan
-  repo: bdd-gh-1582806522
-  url: https://github.com/jstrachan/bdd-gh-1582806522.git
+  repo: bdd-gh-1582806619
+  url: https://github.com/jstrachan/bdd-gh-1582806619.git
   version: ""
   versionURL: ""

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,0 +1,7 @@
+dependencies:
+- host: github.com
+  owner: jstrachan
+  repo: bdd-gh-1582792034
+  url: https://github.com/jstrachan/bdd-gh-1582792034.git
+  version: ""
+  versionURL: ""

--- a/repositories/templates/jstrachan-bdd-gh-1582792034-sr.yaml
+++ b/repositories/templates/jstrachan-bdd-gh-1582792034-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: jstrachan
+    provider: github
+    repository: bdd-gh-1582792034
+  name: jstrachan-bdd-gh-1582792034
+spec:
+  description: Imported application for jstrachan/bdd-gh-1582792034
+  httpCloneURL: https://github.com/jstrachan/bdd-gh-1582792034.git
+  org: jstrachan
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: bdd-gh-1582792034
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/jstrachan/bdd-gh-1582792034.git

--- a/repositories/templates/jstrachan-bdd-gh-1582806522-sr.yaml
+++ b/repositories/templates/jstrachan-bdd-gh-1582806522-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: jstrachan
+    provider: github
+    repository: bdd-gh-1582806522
+  name: jstrachan-bdd-gh-1582806522
+spec:
+  description: Imported application for jstrachan/bdd-gh-1582806522
+  httpCloneURL: https://github.com/jstrachan/bdd-gh-1582806522.git
+  org: jstrachan
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: bdd-gh-1582806522
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/jstrachan/bdd-gh-1582806522.git

--- a/repositories/templates/jstrachan-bdd-gh-1582806619-sr.yaml
+++ b/repositories/templates/jstrachan-bdd-gh-1582806619-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: jstrachan
+    provider: github
+    repository: bdd-gh-1582806619
+  name: jstrachan-bdd-gh-1582806619
+spec:
+  description: Imported application for jstrachan/bdd-gh-1582806619
+  httpCloneURL: https://github.com/jstrachan/bdd-gh-1582806619.git
+  org: jstrachan
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: bdd-gh-1582806619
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/jstrachan/bdd-gh-1582806619.git


### PR DESCRIPTION
Update [jstrachan/bdd-gh-1582806619](https://github.com/jstrachan/bdd-gh-1582806619.git) 

Command run was `jx create quickstart -b --org jstrachan -p bdd-gh-1582806619 -f golang-http --git-provider-url https://github.com`
<hr />

Update [jstrachan/bdd-gh-1582806522](https://github.com/jstrachan/bdd-gh-1582806522.git) 

Command run was `jx create quickstart -b --org jstrachan -p bdd-gh-1582806522 -f golang-http --git-provider-url https://github.com`
<hr />

Update [jstrachan/bdd-gh-1582792034](https://github.com/jstrachan/bdd-gh-1582792034.git) 

Command run was `jx create quickstart -b --org jstrachan -p bdd-gh-1582792034 -f golang-http --git-provider-url https://github.com`